### PR TITLE
Emacs 26 has removed lazy-highlight-face

### DIFF
--- a/fastnav.el
+++ b/fastnav.el
@@ -148,7 +148,7 @@ search of occurences."
                         (let ((ov (make-overlay p (1+ p))))
                           (overlay-put ov 'priority 100)
                           (overlay-put ov 'tag 'fastnav)
-                          (overlay-put ov 'face lazy-highlight-face)
+                          (overlay-put ov 'face 'lazy-highlight)
                           ov)))
                   (fastnav-get-nth-chars arg))
           (let* ((event (read-event))


### PR DESCRIPTION
lazy-highlight-face was declared obsolete in Emacs 22.1 in favor of lazy-highlight, and removed in Emacs 25.1.